### PR TITLE
use format=json, expose more metrics

### DIFF
--- a/nextcloud.conf
+++ b/nextcloud.conf
@@ -1,10 +1,10 @@
 # netdata python.d.plugin configuration for nextcloud
 #
-# url: the URL to get the monitoring data
+# url: the base URL where nextcloud is reachable
 # user: user
 # pass: app password
 
 local:
-    url: 'http://localhost/ocs/v2.php/apps/serverinfo/api/v1/info'
+    url: 'http://localhost'
     user: 'mylogin'
     pass: 'mypassword'


### PR DESCRIPTION
In case you want to use my modifications here they are.
I used format=json because it simplifies parsing (in fact, there's no need to parse at all, just extract the relevant dictionaries from the decoded json).