### PR TITLE
add metadata plugin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ With your default netdata installation copy the nextcloud.chart.py script to
 on your distribution. Read your given release of netdata for more information.
 
 Log in as aministrator in Nextcloud and create a new app password for netdata.
+Note: The [metadata](https://apps.nextcloud.com/apps/metadata) plugin must be installed and activated in Nextcloud.
 
 Edit the config file to set the Nextcloud API URL, user name and app password.
 


### PR DESCRIPTION
Hello again,
As mentioned in #4, I had setup issues because my Nextcloud instance did not have the Metadata plugin installed, so I would include that in the Readme 